### PR TITLE
Add CI to check code format, build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,8 @@ jobs:
         rm -rf ${REPO_NAME}
         git clone ${{ github.server_url }}/${{ github.repository }} ${REPO_NAME}
         cd ${REPO_NAME}
-        git fetch origin pull/${{ github.event.number }}/${{ github.ref }}
-        echo pull/${{ github.event.number }}/${{ github.ref }}
-        git checkout ${{ github.ref }}
+        git fetch origin pull/${{ github.event.number }}/head:${{ github.head_ref }}
+        git checkout ${{ github.head_ref }}
         cp ci/* ${ROOT_DIR}/src/
   build:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check.
+      uses: jidicula/clang-format-action@v4.4.1
+      with:
+        clang-format-version: '13'
+        check-path: 'nn-hal'
+  fetch-push:
+    needs: clang-format
+    if: github.event_name == 'push'
+    runs-on: self-hosted
+    env:
+      ROOT_DIR: /opt/chromeos/workspace
+      REPO_NAME: intel-nnhal-dev
+    steps:
+    - name: Fetch push code.
+      run: |
+        echo ${{ github.event_name }}
+        echo ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+        cd ${ROOT_DIR}/src/third_party/
+        rm -rf ${REPO_NAME}
+        git clone ${{ github.server_url }}/${{ github.repository }} ${REPO_NAME}
+        cd ${REPO_NAME}
+        git checkout ${{ github.sha }}
+        cp ci/* ${ROOT_DIR}/src/
+  fetch-pr:
+    needs: clang-format
+    if: github.event_name == 'pull_request'
+    runs-on: self-hosted
+    env:
+      ROOT_DIR: /opt/chromeos/workspace
+      REPO_NAME: intel-nnhal-dev
+    steps:
+    - name: Fetch pull code.
+      run: |
+        echo ${{ github.event_name }}
+        echo ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+        cd ${ROOT_DIR}/src/third_party/
+        rm -rf ${REPO_NAME}
+        git clone ${{ github.server_url }}/${{ github.repository }} ${REPO_NAME}
+        cd ${REPO_NAME}
+        git fetch origin pull/${{ github.event.number }}/${{ github.ref }}
+        echo pull/${{ github.event.number }}/${{ github.ref }}
+        git checkout ${{ github.ref }}
+        cp ci/* ${ROOT_DIR}/src/
+  build:
+    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+    needs: [fetch-push, fetch-pr]
+    runs-on: self-hosted
+    env:
+      ROOT_DIR: /opt/chromeos/workspace
+    steps:
+    - name: Build and deploy nn-hal.
+      run: |
+        cd ${ROOT_DIR}/src/
+        sh build-test.sh "build"
+  test-functional:
+    if: ${{ always() }}
+    needs: build
+    runs-on: self-hosted
+    env:
+      ROOT_DIR: /opt/chromeos/workspace
+    steps:
+    - name: Run functional tests for nn-hal.
+      run: |
+        cd ${ROOT_DIR}/src/
+        sh build-test.sh "functional"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,46 +11,35 @@ jobs:
       with:
         clang-format-version: '13'
         check-path: 'nn-hal'
-  fetch-push:
+  fetch:
     needs: clang-format
-    if: github.event_name == 'push'
     runs-on: self-hosted
     env:
       ROOT_DIR: /opt/chromeos/workspace
       REPO_NAME: intel-nnhal-dev
     steps:
-    - name: Fetch push code.
+    - name: Clone repo.
       run: |
-        echo ${{ github.event_name }}
         echo ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
         cd ${ROOT_DIR}/src/third_party/
         rm -rf ${REPO_NAME}
         git clone ${{ github.server_url }}/${{ github.repository }} ${REPO_NAME}
         cd ${REPO_NAME}
+    - name: Fetch push code.
+      if: github.event_name == 'push'
+      run: |
+        cd ${ROOT_DIR}/src/third_party/${REPO_NAME}/
         git checkout ${{ github.sha }}
         cp ci/* ${ROOT_DIR}/src/
-  fetch-pr:
-    needs: clang-format
-    if: github.event_name == 'pull_request'
-    runs-on: self-hosted
-    env:
-      ROOT_DIR: /opt/chromeos/workspace
-      REPO_NAME: intel-nnhal-dev
-    steps:
-    - name: Fetch pull code.
+    - name: Fetch pull request code.
+      if: github.event_name == 'pull_request'
       run: |
-        echo ${{ github.event_name }}
-        echo ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
-        cd ${ROOT_DIR}/src/third_party/
-        rm -rf ${REPO_NAME}
-        git clone ${{ github.server_url }}/${{ github.repository }} ${REPO_NAME}
-        cd ${REPO_NAME}
+        cd ${ROOT_DIR}/src/third_party/${REPO_NAME}/
         git fetch origin pull/${{ github.event.number }}/head:${{ github.head_ref }}
         git checkout ${{ github.head_ref }}
         cp ci/* ${ROOT_DIR}/src/
   build:
-    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
-    needs: [fetch-push, fetch-pr]
+    needs: fetch
     runs-on: self-hosted
     env:
       ROOT_DIR: /opt/chromeos/workspace
@@ -60,7 +49,6 @@ jobs:
         cd ${ROOT_DIR}/src/
         sh build-test.sh "build"
   test-functional:
-    if: ${{ always() }}
     needs: build
     runs-on: self-hosted
     env:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CI](https://github.com/reaganlo/nn-hal/actions/workflows/ci.yml/badge.svg)
+
 # Android Neural Networks HAL with OpenVINO supporting hardware accelerators such as /
 Intel® Math Kernel Library for Deep Neural Networks (Intel® MKL-DNN)
 
@@ -38,3 +40,22 @@ Create a pull request on github.com with your patch. Make sure your change is cl
 and passing ULTs.
 
 A maintainer will contact you if there are questions or concerns.
+
+## Continuous Integration
+Before committing any changes, make sure the coding style and testing configs are correct.
+If not, the CI will fail.
+
+### Coding Style
+
+Run the following command to ensure that the proper coding style is being followed:
+```
+    find . -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\)' -exec clang-format -style=file -i {} \;
+```
+
+### Build and Test
+
+Update the BOARD value in [build-test.sh](ci/build-test.sh) as per your test requirement.
+If your BOARD is not supported, please contact the maintainer to get it added.
+
+Currently, the CI builds the intel-nnhal package and runs the following tests:
+- Functional tests that include ml_cmdline and a subset of cts and vts tests.

--- a/ci/0001-Compilation-changes-for-CrOS-ov-master.patch
+++ b/ci/0001-Compilation-changes-for-CrOS-ov-master.patch
@@ -1,0 +1,328 @@
+From c16c2851bbfd1206d89afec71f972d9bcbafff1b Mon Sep 17 00:00:00 2001
+From: Raviraj Sitaram P <raviraj.p.sitaram@intel.com>
+Date: Mon, 16 Aug 2021 15:12:53 +0530
+Subject: [PATCH] Compilation changes for CrOS ov-master
+
+---
+ cmake/dependencies.cmake                           | 44 +++++++++++-----------
+ cmake/developer_package/linux_name.cmake           | 44 +++++++++++-----------
+ cmake/developer_package/plugins/plugins.cmake      | 10 +++--
+ inference-engine/cmake/vpu_dependencies.cmake      | 19 ++++++----
+ .../src/inference_engine/CMakeLists.txt            | 26 +++++++++----
+ inference-engine/src/legacy_api/CMakeLists.txt     |  8 +++-
+ .../low_precision_transformations/CMakeLists.txt   | 14 +++++--
+ inference-engine/src/preprocessing/CMakeLists.txt  | 10 +++--
+ .../src/transformations/CMakeLists.txt             | 15 ++++++--
+ ngraph/CMakeLists.txt                              | 12 ++++--
+ 10 files changed, 127 insertions(+), 75 deletions(-)
+
+diff --git a/cmake/dependencies.cmake b/cmake/dependencies.cmake
+index 82f98b4c515f..38ffa015d8d5 100644
+--- a/cmake/dependencies.cmake
++++ b/cmake/dependencies.cmake
+@@ -27,28 +27,30 @@ if(COMMAND get_linux_name)
+     get_linux_name(LINUX_OS_NAME)
+ endif()
+ 
+-if(CMAKE_CROSSCOMPILING AND CMAKE_HOST_SYSTEM_NAME MATCHES Linux AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
+-    set(protoc_version "3.9.2")
+-
+-    RESOLVE_DEPENDENCY(SYSTEM_PROTOC_ROOT
+-        ARCHIVE_LIN "protoc-${protoc_version}-linux-x86_64.tar.gz"
+-        TARGET_PATH "${TEMP}/protoc-${protoc_version}-linux-x86_64"
+-        SHA256 "1d6da1d97d0cbfcd333558afe24533eb3cb48dc1e0ab5e971aa1e50ede8bcf45"
+-    )
+-    debug_message(STATUS "host protoc-${protoc_version} root path = " ${SYSTEM_PROTOC_ROOT})
+-
+-    reset_deps_cache(SYSTEM_PROTOC)
+-
+-    find_host_program(
+-        SYSTEM_PROTOC
+-        NAMES protoc
+-        PATHS "${SYSTEM_PROTOC_ROOT}/bin"
+-        NO_DEFAULT_PATH)
+-    if(NOT SYSTEM_PROTOC)
+-        message(FATAL_ERROR "[ONNX IMPORTER] Missing host protoc binary")
+-    endif()
++if (NOT ${TARGET_OS} STREQUAL "CHROMEOS")
++    if(CMAKE_CROSSCOMPILING AND CMAKE_HOST_SYSTEM_NAME MATCHES Linux AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
++        set(protoc_version "3.9.2")
++
++        RESOLVE_DEPENDENCY(SYSTEM_PROTOC_ROOT
++            ARCHIVE_LIN "protoc-${protoc_version}-linux-x86_64.tar.gz"
++            TARGET_PATH "${TEMP}/protoc-${protoc_version}-linux-x86_64"
++            SHA256 "1d6da1d97d0cbfcd333558afe24533eb3cb48dc1e0ab5e971aa1e50ede8bcf45"
++        )
++        debug_message(STATUS "host protoc-${protoc_version} root path = " ${SYSTEM_PROTOC_ROOT})
++
++        reset_deps_cache(SYSTEM_PROTOC)
++
++        find_host_program(
++            SYSTEM_PROTOC
++            NAMES protoc
++            PATHS "${SYSTEM_PROTOC_ROOT}/bin"
++            NO_DEFAULT_PATH)
++        if(NOT SYSTEM_PROTOC)
++            message(FATAL_ERROR "[ONNX IMPORTER] Missing host protoc binary")
++        endif()
+ 
+-    update_deps_cache(SYSTEM_PROTOC "${SYSTEM_PROTOC}" "Path to host protoc for ONNX Importer")
++        update_deps_cache(SYSTEM_PROTOC "${SYSTEM_PROTOC}" "Path to host protoc for ONNX Importer")
++    endif()
+ endif()
+ 
+ if(ENABLE_MYRIAD)
+diff --git a/cmake/developer_package/linux_name.cmake b/cmake/developer_package/linux_name.cmake
+index 645c71da3568..b93e6c54d36f 100644
+--- a/cmake/developer_package/linux_name.cmake
++++ b/cmake/developer_package/linux_name.cmake
+@@ -6,29 +6,31 @@ include(target_flags)
+ 
+ if (LINUX)
+     function(get_linux_name res_var)
+-        if (NOT EXISTS "/etc/lsb-release")
+-            execute_process(COMMAND find -L /etc/ -maxdepth 1 -type f -name *-release -exec cat {} \;
+-                    OUTPUT_VARIABLE release_data RESULT_VARIABLE result)
+-            string(REPLACE "Red Hat" "CentOS" release_data "${release_data}")
+-            set(name_regex "NAME=\"([^ \"\n]*).*\"\n")
+-            set(version_regex "VERSION=\"([0-9]+(\\.[0-9]+)?)[^\n]*\"")
+-        else ()
+-            # linux version detection using cat /etc/lsb-release
+-            file(READ "/etc/lsb-release" release_data)
+-            set(name_regex "DISTRIB_ID=([^ \n]*)\n")
+-            set(version_regex "DISTRIB_RELEASE=([0-9]+(\\.[0-9]+)?)")
+-        endif ()
++	if (NOT ${TARGET_OS} STREQUAL "CHROMEOS")
++		if (NOT EXISTS "/etc/lsb-release")
++		    execute_process(COMMAND find -L /etc/ -maxdepth 1 -type f -name *-release -exec cat {} \;
++			    OUTPUT_VARIABLE release_data RESULT_VARIABLE result)
++		    string(REPLACE "Red Hat" "CentOS" release_data "${release_data}")
++		    set(name_regex "NAME=\"([^ \"\n]*).*\"\n")
++		    set(version_regex "VERSION=\"([0-9]+(\\.[0-9]+)?)[^\n]*\"")
++		else ()
++		    # linux version detection using cat /etc/lsb-release
++		    file(READ "/etc/lsb-release" release_data)
++		    set(name_regex "DISTRIB_ID=([^ \n]*)\n")
++		    set(version_regex "DISTRIB_RELEASE=([0-9]+(\\.[0-9]+)?)")
++		endif ()
+ 
+-        string(REGEX MATCH ${name_regex} name ${release_data})
+-        set(os_name ${CMAKE_MATCH_1})
++		string(REGEX MATCH ${name_regex} name ${release_data})
++		set(os_name ${CMAKE_MATCH_1})
+ 
+-        string(REGEX MATCH ${version_regex} version ${release_data})
+-        set(os_name "${os_name} ${CMAKE_MATCH_1}")
++		string(REGEX MATCH ${version_regex} version ${release_data})
++		set(os_name "${os_name} ${CMAKE_MATCH_1}")
+ 
+-        if (os_name)
+-            set(${res_var} ${os_name} PARENT_SCOPE)
+-        else ()
+-            set(${res_var} NOTFOUND PARENT_SCOPE)
+-        endif ()
++		if (os_name)
++		    set(${res_var} ${os_name} PARENT_SCOPE)
++		else ()
++		    set(${res_var} NOTFOUND PARENT_SCOPE)
++		endif ()
++	endif()
+     endfunction()
+ endif ()
+diff --git a/cmake/developer_package/plugins/plugins.cmake b/cmake/developer_package/plugins/plugins.cmake
+index 6210ede333ad..1721007b9d2d 100644
+--- a/cmake/developer_package/plugins/plugins.cmake
++++ b/cmake/developer_package/plugins/plugins.cmake
+@@ -121,9 +121,13 @@ function(ie_add_plugin)
+     if(NOT IE_PLUGIN_SKIP_INSTALL)
+         string(TOLOWER "${IE_PLUGIN_DEVICE_NAME}" install_component)
+         ie_cpack_add_component(${install_component} REQUIRED DEPENDS core)
+-
+-        install(TARGETS ${IE_PLUGIN_NAME}
+-                LIBRARY DESTINATION ${IE_CPACK_RUNTIME_PATH} COMPONENT ${install_component})
++        if (${TARGET_OS} STREQUAL "CHROMEOS")
++            install(TARGETS ${IE_PLUGIN_NAME}
++                    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${install_component})
++        else()
++            install(TARGETS ${IE_PLUGIN_NAME}
++                    LIBRARY DESTINATION ${IE_CPACK_RUNTIME_PATH} COMPONENT ${install_component})
++        endif()
+     endif()
+ endfunction()
+ 
+diff --git a/inference-engine/cmake/vpu_dependencies.cmake b/inference-engine/cmake/vpu_dependencies.cmake
+index e6ec3799a3cc..e25623ab0c8b 100644
+--- a/inference-engine/cmake/vpu_dependencies.cmake
++++ b/inference-engine/cmake/vpu_dependencies.cmake
+@@ -33,14 +33,17 @@ foreach(idx RANGE 0 ${num_firmwares})
+     endif ()
+ 
+     reset_deps_cache(VPU_FIRMWARE_${firmware_name_upper}_FILE)
+-
+-    RESOLVE_DEPENDENCY(VPU_FIRMWARE_${firmware_name_upper}
+-        ARCHIVE_UNIFIED VPU/${firmware_name}/firmware_${firmware_name}_${FIRMWARE_PACKAGE_VERSION}.zip
+-        TARGET_PATH "${TEMP}/vpu/firmware/${firmware_name}"
+-        ENVIRONMENT "VPU_FIRMWARE_${firmware_name_upper}_FILE"
+-        FOLDER
+-        SHA256 ${hash})
+-    debug_message(STATUS "${firmware_name}=" ${VPU_FIRMWARE_${firmware_name_upper}})
++    if (NOT ${TARGET_OS} STREQUAL "CHROMEOS")
++        RESOLVE_DEPENDENCY(VPU_FIRMWARE_${firmware_name_upper}
++            ARCHIVE_UNIFIED VPU/${firmware_name}/firmware_${firmware_name}_${FIRMWARE_PACKAGE_VERSION}.zip
++            TARGET_PATH "${TEMP}/vpu/firmware/${firmware_name}"
++            ENVIRONMENT "VPU_FIRMWARE_${firmware_name_upper}_FILE"
++            FOLDER
++            SHA256 ${hash})
++        debug_message(STATUS "${firmware_name}=" ${VPU_FIRMWARE_${firmware_name_upper}})
++    else()
++        set(VPU_FIRMWARE_${firmware_name_upper} ${TEMP}/vpu/firmware/${firmware_name})
++    endif()
+ 
+     update_deps_cache(
+         VPU_FIRMWARE_${firmware_name_upper}_FILE
+diff --git a/inference-engine/src/inference_engine/CMakeLists.txt b/inference-engine/src/inference_engine/CMakeLists.txt
+index e79a57093669..039f4f62c5b2 100644
+--- a/inference-engine/src/inference_engine/CMakeLists.txt
++++ b/inference-engine/src/inference_engine/CMakeLists.txt
+@@ -278,14 +278,24 @@ ie_cpack_add_component(core_dev REQUIRED core ngraph_dev)
+ install(DIRECTORY "${PUBLIC_HEADERS_DIR}" DESTINATION ${IE_CPACK_IE_DIR}
+         COMPONENT core_dev)
+ 
+-install(TARGETS ${TARGET_NAME} EXPORT InferenceEngineTargets
+-        RUNTIME DESTINATION ${IE_CPACK_RUNTIME_PATH} COMPONENT core
+-        ARCHIVE DESTINATION ${IE_CPACK_ARCHIVE_PATH} COMPONENT core
+-        LIBRARY DESTINATION ${IE_CPACK_LIBRARY_PATH} COMPONENT core)
+-
+-install(FILES $<TARGET_FILE_DIR:${TARGET_NAME}>/plugins.xml
+-        DESTINATION ${IE_CPACK_RUNTIME_PATH}
+-        COMPONENT core)
++if (${TARGET_OS} STREQUAL "CHROMEOS")
++    install(TARGETS ${TARGET_NAME} EXPORT InferenceEngineTargets
++                RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT core
++                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT core
++                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT core)
++    install(FILES $<TARGET_FILE_DIR:${TARGET_NAME}>/plugins.xml
++                DESTINATION ${CMAKE_INSTALL_LIBDIR}
++                COMPONENT core)
++elseif()
++	install(TARGETS ${TARGET_NAME} EXPORT InferenceEngineTargets
++		RUNTIME DESTINATION ${IE_CPACK_RUNTIME_PATH} COMPONENT core
++		ARCHIVE DESTINATION ${IE_CPACK_ARCHIVE_PATH} COMPONENT core
++		LIBRARY DESTINATION ${IE_CPACK_LIBRARY_PATH} COMPONENT core)
++
++	install(FILES $<TARGET_FILE_DIR:${TARGET_NAME}>/plugins.xml
++		DESTINATION ${IE_CPACK_RUNTIME_PATH}
++		COMPONENT core)
++endif()
+ 
+ # for InferenceEngineUnitTest
+ if(WIN32)
+diff --git a/inference-engine/src/legacy_api/CMakeLists.txt b/inference-engine/src/legacy_api/CMakeLists.txt
+index 9de8bf169108..dda156f7296e 100644
+--- a/inference-engine/src/legacy_api/CMakeLists.txt
++++ b/inference-engine/src/legacy_api/CMakeLists.txt
+@@ -78,7 +78,13 @@ set_target_properties(${TARGET_NAME} ${TARGET_NAME}_obj
+ openvino_developer_export_targets(COMPONENT inference_engine TARGETS ${TARGET_NAME})
+ 
+ # install
+-
++if (${TARGET_OS} STREQUAL "CHROMEOS")
++    install(TARGETS ${TARGET_NAME}
++            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT core
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT core
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT core)
++elseif()
+ install(TARGETS ${TARGET_NAME}
+         RUNTIME DESTINATION ${IE_CPACK_RUNTIME_PATH} COMPONENT core
+         LIBRARY DESTINATION ${IE_CPACK_LIBRARY_PATH} COMPONENT core)
++endif()
+\ No newline at end of file
+diff --git a/inference-engine/src/low_precision_transformations/CMakeLists.txt b/inference-engine/src/low_precision_transformations/CMakeLists.txt
+index 7f9d34e7149c..974f50364215 100644
+--- a/inference-engine/src/low_precision_transformations/CMakeLists.txt
++++ b/inference-engine/src/low_precision_transformations/CMakeLists.txt
+@@ -47,6 +47,14 @@ openvino_developer_export_targets(COMPONENT inference_engine TARGETS ${TARGET_NA
+ 
+ # install
+ 
+-install(TARGETS ${TARGET_NAME}
+-        RUNTIME DESTINATION ${IE_CPACK_RUNTIME_PATH} COMPONENT core
+-        LIBRARY DESTINATION ${IE_CPACK_LIBRARY_PATH} COMPONENT core)
++if (${TARGET_OS} STREQUAL "CHROMEOS")
++    install(TARGETS ${TARGET_NAME}
++            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT core
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT core
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT core)
++else()
++    install(TARGETS ${TARGET_NAME}
++            RUNTIME DESTINATION ${IE_CPACK_RUNTIME_PATH} COMPONENT core
++            ARCHIVE DESTINATION ${IE_CPACK_ARCHIVE_PATH} COMPONENT core
++            LIBRARY DESTINATION ${IE_CPACK_LIBRARY_PATH} COMPONENT core)
++endif()
+diff --git a/inference-engine/src/preprocessing/CMakeLists.txt b/inference-engine/src/preprocessing/CMakeLists.txt
+index a118f638c6ad..47179641ec9a 100644
+--- a/inference-engine/src/preprocessing/CMakeLists.txt
++++ b/inference-engine/src/preprocessing/CMakeLists.txt
+@@ -170,6 +170,10 @@ set_target_properties(${TARGET_NAME} ${TARGET_NAME}_obj ${TARGET_NAME}_s
+ openvino_developer_export_targets(COMPONENT inference_engine TARGETS ${TARGET_NAME})
+ 
+ # install
+-
+-install(TARGETS ${TARGET_NAME}
+-        LIBRARY DESTINATION ${IE_CPACK_RUNTIME_PATH} COMPONENT core)
++if (${TARGET_OS} STREQUAL "CHROMEOS")
++    install(TARGETS ${TARGET_NAME}
++            LIBRARY DESTINATION ${IE_CPACK_RUNTIME_PATH} COMPONENT core)
++else()
++    install(TARGETS ${TARGET_NAME}
++            LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT core)
++endif()
+diff --git a/inference-engine/src/transformations/CMakeLists.txt b/inference-engine/src/transformations/CMakeLists.txt
+index bf4a4f31d6ae..2cf70e683777 100644
+--- a/inference-engine/src/transformations/CMakeLists.txt
++++ b/inference-engine/src/transformations/CMakeLists.txt
+@@ -49,7 +49,14 @@ openvino_developer_export_targets(COMPONENT inference_engine TARGETS ${TARGET_NA
+ 
+ # install
+ 
+-install(TARGETS ${TARGET_NAME} EXPORT InferenceEngineTargets
+-        RUNTIME DESTINATION ${IE_CPACK_RUNTIME_PATH} COMPONENT core
+-        ARCHIVE DESTINATION ${IE_CPACK_ARCHIVE_PATH} COMPONENT core
+-        LIBRARY DESTINATION ${IE_CPACK_LIBRARY_PATH} COMPONENT core)
++if (${TARGET_OS} STREQUAL "CHROMEOS")
++    install(TARGETS ${TARGET_NAME} EXPORT InferenceEngineTargets
++            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT core
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT core
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT core)
++else()
++    install(TARGETS ${TARGET_NAME} EXPORT InferenceEngineTargets
++            RUNTIME DESTINATION ${IE_CPACK_RUNTIME_PATH} COMPONENT core
++            ARCHIVE DESTINATION ${IE_CPACK_ARCHIVE_PATH} COMPONENT core
++            LIBRARY DESTINATION ${IE_CPACK_LIBRARY_PATH} COMPONENT core)
++endif()
+diff --git a/ngraph/CMakeLists.txt b/ngraph/CMakeLists.txt
+index 6ef6b3cdeb6b..654e61f079d5 100644
+--- a/ngraph/CMakeLists.txt
++++ b/ngraph/CMakeLists.txt
+@@ -16,9 +16,15 @@ project (ngraph)
+ # Installation logic...
+ #-----------------------------------------------------------------------------------------------
+ 
+-set(NGRAPH_INSTALL_LIB "deployment_tools/ngraph/lib")
+-set(NGRAPH_INSTALL_INCLUDE "deployment_tools/ngraph/include")
+-set(NGRAPH_TARGETS_FILE "${CMAKE_CURRENT_BINARY_DIR}/ngraphTargets.cmake")
++if (${TARGET_OS} STREQUAL "CHROMEOS")
++    set(NGRAPH_INSTALL_LIB "${CMAKE_INSTALL_LIBDIR}")
++    set(NGRAPH_INSTALL_INCLUDE "deployment_tools/ngraph/include")
++    set(NGRAPH_TARGETS_FILE "${CMAKE_CURRENT_BINARY_DIR}/ngraphTargets.cmake")
++else()
++    set(NGRAPH_INSTALL_LIB "deployment_tools/ngraph/lib")
++    set(NGRAPH_INSTALL_INCLUDE "deployment_tools/ngraph/include")
++    set(NGRAPH_TARGETS_FILE "${CMAKE_CURRENT_BINARY_DIR}/ngraphTargets.cmake")
++endif()
+ 
+ add_definitions(-DPROJECT_ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+ 
+-- 
+2.7.4
+

--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+## Update the BOARD based on the testing requirement. ##
+## Currently the following boards are supported:      ##
+## - volteer                                          ##
+BOARD=volteer
+ACTION=$1
+
+red=`tput setaf 1`
+green=`tput setaf 2`
+blue=`tput setaf 4`
+reset=`tput sgr0`
+
+# Function to run command.
+runCmd() {
+        echo "${blue}RUN: \"${cmd}\"${reset}"
+        ${cmd}
+        status=$?
+        if [ ${status} -eq 0 ]; then
+                echo "${green}SUCCESS: \"${cmd}\"${reset}"
+        else
+                echo "${red}FAIL: \"${cmd}\"${reset}"
+                exit 1
+        fi
+}
+
+# Function to return correct status for ml_cmdline based on output log.
+# This function is required because, by default, ml_cmdline
+# always returns status 0 irrespective of whether it failed or not.
+mlCmdline() {
+	sub_cmd="ssh root@${IPADDRESS} ml_cmdline --nnapi"
+	if ! ${sub_cmd} | grep "Status: OK" ; then
+		return 1
+	else
+		return 0
+	fi
+}
+
+# Function to get DUT IP address from config file based on BOARD.
+getBoardAddr() {
+	IPADDRESS=$(awk -v key=${BOARD} -F "=" 'BEGIN{/key/} {print $2}' boards.ini | tr -d ' ' | sed -r '/^\s*$/d')
+	echo ${IPADDRESS}
+	if [ -z "${IPADDRESS}" ]; then
+		echo "${red}ERROR: Unsupported BOARD=${BOARD}.${reset}"
+		exit 1
+	fi
+}
+
+getBoardAddr
+
+echo ${ACTION}
+if [ "${ACTION}" = "build" ]; then
+
+	cmd="cros_sdk --enter"
+	runCmd
+
+	cmd="cros_sdk -- cros_workon-${BOARD} start intel-nnhal"
+	runCmd
+
+	cmd="cros_sdk USE=\"vendor-nnhal\" -- emerge-${BOARD} intel-nnhal"
+	runCmd
+
+	cmd="cros_sdk -- cros_workon_make --board=${BOARD} --install intel-nnhal"
+	runCmd
+
+	cmd="cros_sdk -- cros deploy ssh://${IPADDRESS} intel-nnhal"
+	runCmd
+
+elif [ "${ACTION}" = "functional" ]; then
+
+	# Run nnapi ml test
+	cmd=mlCmdline
+	runCmd
+
+	# Run required cts tests
+	cmd="ssh root@${IPADDRESS} export ANDROID_LOG_TAGS=\"*:f\" && cros_nnapi_cts --gtest_filter=-Validation*:TestGenerated*:TestRandom*:Generated*:UnknownCombinations*"
+	runCmd
+
+        # Run subset of nnapi vts 1_0 tests
+        cmd="ssh root@${IPADDRESS} export ANDROID_LOG_TAGS=\"*:f\" && cros_nnapi_vts_1_0 --gtest_filter=-Validation*:TestGenerated*:TestRandom*:Generated*:UnknownCombinations*"
+	runCmd
+
+        # Run subset of nnapi vts 1_1 tests
+        cmd="ssh root@${IPADDRESS} export ANDROID_LOG_TAGS=\"*:f\" && cros_nnapi_vts_1_1 --gtest_filter=-Validation*:TestGenerated*:TestRandom*:Generated*:UnknownCombinations*"
+	runCmd
+
+        # Run subset of nnapi vts 1_2 tests
+        cmd="ssh root@${IPADDRESS} export ANDROID_LOG_TAGS=\"*:f\" && cros_nnapi_vts_1_2 --gtest_filter=-Validation*:TestGenerated*:TestRandom*:Generated*:UnknownCombinations*"
+	runCmd
+
+        # Run subset of  nnapi vts 1_3 tests
+	cmd="ssh root@${IPADDRESS} export ANDROID_LOG_TAGS=\"*:f\" && cros_nnapi_vts_1_3 --gtest_filter=-Validation*:TestGenerated*:TestRandom*:Generated*:UnknownCombinations*"
+	runCmd
+
+elif [ "${ACTION}" = "regression" ]; then
+	# Copy test script to DUT
+	scp cts-vts.py root@${IPADDRESS}:~/
+
+	# Run nnapi cts tests
+	cmd="ssh root@${IPADDRESS} export ANDROID_LOG_TAGS=\"*:f\" && python cts-vts.py --cts"
+	runCmd
+	scp root@${IPADDRESS}:~/cts_*.csv . # Copy test result to host server
+	ssh root@${IPADDRESS} rm -f cts_*.csv # Delete test result to save space in DUT
+
+	# Run nnapi vts_1_0 tests
+	cmd="ssh root@${IPADDRESS} python cts-vts.py --vts10"
+	runCmd
+        scp root@${IPADDRESS}:~/vts10_*.csv . # Copy test result to host server
+        ssh root@${IPADDRESS} rm -f vts10_*.csv # Delete test result to save space in DUT
+
+        # Run nnapi vts_1_1 tests
+        cmd="ssh root@${IPADDRESS} python cts-vts.py --vts11"
+        runCmd
+        scp root@${IPADDRESS}:~/vts11_*.csv . # Copy test result to host server
+        ssh root@${IPADDRESS} rm -f vts11_*.csv # Delete test result to save space in DUT
+
+        # Run nnapi vts_1_2 tests
+        cmd="ssh root@${IPADDRESS} python cts-vts.py --vts12"
+        runCmd
+        scp root@${IPADDRESS}:~/vts12_*.csv . # Copy test result to host server
+        ssh root@${IPADDRESS} rm -f vts12_*.csv # Delete test result to save space in DUT
+
+        # Run nnapi vts_1_3 tests
+        cmd="ssh root@${IPADDRESS} python cts-vts.py --vts13"
+        runCmd
+        scp root@${IPADDRESS}:~/vts13_*.csv . # Copy test result to host server
+        ssh root@${IPADDRESS} rm -f vts13_*.csv # Delete test result to save space in DUT
+fi

--- a/ci/cts-vts.py
+++ b/ci/cts-vts.py
@@ -1,0 +1,174 @@
+# This scripts runs cts/vts tests and writes results to a timestamped csv file.
+# Run "python cts_vts.py --help" for usage details.
+import os
+import sys
+import getopt
+import time
+import datetime
+import subprocess
+from joblib import Parallel, delayed
+import json
+
+count = 0
+total = 0
+passed = 0
+skipped = 0
+failed = 0
+error = 0
+hang = 0
+shared_result = set()
+test_suite_binary = ""
+
+def main(argv):
+	global total
+	global test_suite_binary
+	try:
+		opts, args = getopt.getopt(argv, "" , ["help", "cts", "vts10", "vts11", "vts12", "vts13"])
+	except getopt.GetoptError as err:
+		print(err.msg)
+		print_usage()
+
+	if not opts: # if opts is empty
+		print_usage()
+
+	for opt, arg in opts:
+		if opt == "--help":
+			print_usage()
+		elif opt == "--cts":
+			test_suite_binary = "cros_nnapi_cts"
+		elif opt == "--vts10":
+			test_suite_binary = "cros_nnapi_vts_1_0"
+		elif opt == "--vts11":
+			test_suite_binary = "cros_nnapi_vts_1_1"
+		elif opt == "--vts12":
+			test_suite_binary = "cros_nnapi_vts_1_2"
+		elif opt == "--vts13":
+			test_suite_binary = "cros_nnapi_vts_1_3"
+		else:
+			print_usage()
+
+	now = datetime.datetime.now()
+	print("Start time: {}".format(now))
+	begin = time.time()
+
+	tests = get_tests()
+	print("Running {0} {1} tests. Please wait..".format(total, test_suite_binary))
+
+	# Run tests concurrently. (n_cpus + 1 + n_jobs) are used.
+	Parallel(n_jobs=-2, require='sharedmem')(delayed(run_test)(test) for test in tests)
+	#for ltest in list_tests:
+	#	run_test(ltest)
+
+	output_file = opt.lstrip("-") + "_" + now.strftime("%Y%m%d_%H%M%S") + ".csv"
+	print("Writing results to output file {}. Please wait..".format(output_file))
+	with open(output_file, "w") as out:
+		heading = "VTS/CTS Command" + "," + "Result"
+		print(heading, file=out)
+		for result in shared_result:
+			print(result, file=out)
+
+	end = time.time()
+	summary()
+
+	print("Duration (sec): {}".format(end - begin))
+
+def print_usage():
+		print("USAGE    : python cts-vts.py --<options>")
+		print("OPTIONS  :")
+		print("  --help : Provides usage details")
+		print("  --cts  : Runs the cros_nnapi_cts tests")
+		print("  --vts10: Runs the cros_nnapi_vts_1_0 tests")
+		print("  --vts11: Runs the cros_nnapi_vts_1_1 tests")
+		print("  --vts12: Runs the cros_nnapi_vts_1_2 tests")
+		print("  --vts13: Runs the cros_nnapi_vts_1_3 tests")
+		print("Results are written to output file <options>_<timestamp>.csv")
+		sys.exit(0)
+
+def get_tests():
+	global test_suite_binary
+	global total
+	tests = []
+
+	get_tests_file = test_suite_binary + ".json"
+	get_tests_cmd = test_suite_binary + " " + "--gtest_list_tests" + " " + "--gtest_output=json:" + get_tests_file
+	subprocess.getoutput(get_tests_cmd)
+	time.sleep(5)
+
+	with open(get_tests_file) as json_file:
+			data = json.load(json_file)
+			total = data["tests"]
+			for ts in data["testsuites"]:
+					test_suite = ts["name"]
+					test_name = ""
+					for t in ts["testsuite"]:
+						test_name = test_suite + "." + t["name"]
+						tests.append(test_name)
+
+			if os.path.exists(get_tests_file):
+				os.remove(get_tests_file)
+			else:
+				print("Could not remove file {}. The file does not exist.".format(get_tests_file))
+
+	return tests
+
+def run_test(ltest):
+	status = ""
+	global count
+	global total
+	global passed
+	global skipped
+	global failed
+	global error
+	global hang
+	global test_suite_binary
+
+	test = ltest.strip().split(" ", 1)[0]
+	test_cmd = test_suite_binary + " " + " --gtest_filter=" + test
+
+	proc = subprocess.Popen(test_cmd,stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=True)
+	try:
+		out, err = proc.communicate(timeout=10)
+	except subprocess.TimeoutExpired:
+		proc.kill()
+		hang = hang + 1
+		status = "HANG"
+		result = test_cmd + "," + status
+		shared_result.add(result)
+		return
+
+	if "[  SKIPPED ]" in str(out):
+		skipped = skipped + 1
+		status = "SKIPPED"
+	elif "[  FAILED ]" in str(out):
+		failed = failed + 1
+		status = "FAILED"
+	elif "[  PASSED  ]" in str(out):
+		passed = passed + 1
+		status = "PASSED"
+	else:
+		error = error + 1
+		status = "ERROR " + "(" + str(proc.returncode) + ")"
+
+	result = test_cmd + "," + status
+	os.system("rm -rf /var/spool/crash/*")
+
+	shared_result.add(result)
+
+	count = count + 1
+	if count % 1000 == 0:
+                print("Completed [{}/{}] tests..".format(count, total))
+
+	return
+
+def summary():
+	print("*******SUMMARY*******")
+	print(" PASSED  = %d" %(passed))
+	print(" SKIPPED = %d" %(skipped))
+	print(" FAILED  = %d" %(failed))
+	print(" ERROR   = %d" %(error))
+	print(" HANG    = %d" %(hang))
+	print(" TOTAL   = %d" %(total))
+	print("*********END*********")
+
+if __name__ == "__main__":
+	main(sys.argv[1:])

--- a/ci/intel-nnhal-9999.ebuild
+++ b/ci/intel-nnhal-9999.ebuild
@@ -1,0 +1,53 @@
+# Copyright 2020 The Chromium OS Authors. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+CROS_WORKON_PROJECT=("chromiumos/platform2" "third_party/intel-nnhal-dev" "third_party/intel-openvino-dev")
+CROS_WORKON_LOCALNAME=("platform2" "third_party/intel-nnhal-dev" "third_party/intel-openvino-dev")
+CROS_WORKON_DESTDIR=("${S}/platform2" "${S}/platform2/intel-nnhal-dev" "${S}/platform2/intel-openvino-dev")
+CROS_WORKON_SUBTREE=("common-mk intel-nnhal-dev .gn" "" "")
+
+PLATFORM_SUBDIR="intel-nnhal-dev"
+
+inherit cros-debug cros-workon platform
+
+DESCRIPTION="Intel NNAPI HAL"
+HOMEPAGE="https://github.com/intel/nn-hal"
+
+LICENSE="BSD-Google"
+KEYWORDS="*"
+SLOT="0/0"
+
+RDEPEND="
+	chromeos-base/aosp-frameworks-ml-nn
+	chromeos-base/intel-openvino
+"
+
+DEPEND="
+	>=dev-libs/openssl-1.0.1:0
+	${RDEPEND}
+"
+RESTRICT="strip"
+
+src_prepare() {
+	append-cxxflags "-g -O2 -ggdb"
+
+	cros_enable_cxx_exceptions
+	eapply_user
+}
+
+src_configure() {
+	if use x86 || use amd64; then
+		append-cppflags "-D_Float16=__fp16"
+		append-cxxflags "-Xclang -fnative-half-type"
+		append-cxxflags "-Xclang -fallow-half-arguments-and-returns"
+	fi
+	platform_src_configure
+}
+
+src_install() {
+	dolib.so "${OUT}/lib/libvendor-nn-hal.so"
+	dolib.so "${OUT}/lib/libintel_nnhal.so"
+	#dostrip -x "${OUT}/lib/libintel_nnhal.so"
+}

--- a/ci/intel-openvino-9999.ebuild
+++ b/ci/intel-openvino-9999.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake-utils git-r3 flag-o-matic cros-workon
+
+DESCRIPTION="Intel OpenVino Toolkit"
+HOMEPAGE="https://github.com/openvinotoolkit/openvino"
+
+CMAKE_BUILD_TYPE="Debug"
+LICENSE="BSD-Google"
+KEYWORDS="-* amd64"
+IUSE="+clang"
+SLOT="0"
+
+CROS_WORKON_PROJECT="third_party/intel-openvino-dev"
+CROS_WORKON_LOCALNAME="third_party/intel-openvino-dev"
+
+RDEPEND="
+        dev-libs/protobuf
+        media-libs/opencv
+"
+
+DEPEND="
+	${RDEPEND}
+"
+src_preapre() {
+    eapply_user
+    cmake-utils_src_prepare
+}
+
+src_configure() {
+	cros_enable_cxx_exceptions
+	append-flags "-Wno-error -frtti -msse4.2 -fvisibility=default -Wno-macro-redefined"
+	CPPFLAGS="-I${S}/inference-engine/gna/include -I${S}/inference-engine/omp/include -I${S}/ngraph/src -I${S}/inference_engine/ngraph_ops ${CPPFLAGS}"
+
+	local mycmakeargs=(
+                -DCMAKE_INSTALL_PREFIX="/usr/local/"
+		-DCMAKE_BUILD_TYPE=Debug
+		-DENABLE_CLDNN=OFF
+		-DENABLE_GNA=OFF
+		-DENABLE_NGRAPH=ON
+                -DENABLE_FUNCTIONAL_TESTS=OFF
+		-DTHREADING=SEQ
+		-DENABLE_MKL_DNN=ON
+		-DTARGET_OS="CHROMEOS"
+		-DENABLE_OPENCV=OFF
+		-DENABLE_SAMPLES=ON
+                -DENABLE_TESTS=OFF
+		-DBUILD_SHARED_LIBS=ON
+                -DENABLE_PROTOC=OFF
+                -DNGRAPH_ONNX_IMPORT_ENABLE=OFF
+                -DNGRAPH_TEST_UTIL_ENABLE=OFF
+                -DENABLE_MYRIAD=OFF
+                -DENABLE_VPU=ON
+                -DENABLE_SPEECH_DEMO=OFF
+                -DGFLAGS_INSTALL_HEADERS=OFF
+		-DNGRAPH_ONNX_IMPORT_ENABLE=OFF
+                -DNGRAPH_ONNX_FRONTEND_ENABLE=OFF
+                -DNGRAPH_PDPD_FRONTEND_ENABLE=OFF
+	)
+	cmake-utils_src_configure
+}
+
+src_install() {
+	cmake-utils_src_install
+
+        exeinto /usr/local/bin
+        doexe ${S}/bin/intel64/Debug/hello_query_device
+}

--- a/coding_style.txt
+++ b/coding_style.txt
@@ -1,2 +1,0 @@
-# Before commiting any changes, run the following command to make sure proper coding style is followed
-find . -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\)' -exec clang-format -style=file -i {} \;

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-Test file for commit changes.

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+Test file for commit changes.


### PR DESCRIPTION
Currently the CI does the following:
- Checks code style using clang format.
- Builds intel-nnhal package.
- Deploys package to a volteer DUT.
- Runs functional tests that include ml_cmdline and a subset
  of cts-vts tests.

In order to prevent malicious usage of the CI workflow,
the CI jobs require manual approval from a maintainer.

Refer to the Continuous Integration section in the README
for more details.

Signed-off-by: reagan.lopez@intel.com <reagan.lopez@intel.com>